### PR TITLE
feat: variadic helper functions

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -593,14 +593,15 @@ func (v *evalVisitor) callFunc(name string, funcVal reflect.Value, options *Opti
 	// @todo Is there a better way to do that ?
 	strType := reflect.TypeOf("")
 	boolType := reflect.TypeOf(true)
+	optionsType := reflect.TypeOf(options)
 
 	// check parameters number
 	addOptions := false
 	numIn := funcType.NumIn()
 
-	if numIn == len(params)+1 {
+	if numIn == len(params)+1 || (numIn <= len(params) && numIn > 0) {
 		lastArgType := funcType.In(numIn - 1)
-		if reflect.TypeOf(options).AssignableTo(lastArgType) {
+		if lastArgType.AssignableTo(optionsType) {
 			addOptions = true
 		}
 	}
@@ -624,6 +625,11 @@ func (v *evalVisitor) callFunc(name string, funcVal reflect.Value, options *Opti
 				// @todo Maybe we can panic on that
 				return reflect.Zero(strType)
 			}
+		}
+
+		// support passing options as last argument that would capture remaining params
+		if addOptions && argType.AssignableTo(optionsType) && i == numIn-1 {
+			break
 		}
 
 		if !arg.Type().AssignableTo(argType) {

--- a/helper_test.go
+++ b/helper_test.go
@@ -38,6 +38,16 @@ func gnakHelper(nb int) string {
 	return result
 }
 
+func variadicHelper(options *Options) string {
+	params := options.Params()
+
+	result := ""
+	for i := 0; i < len(params); i++ {
+		result += Str(params[i])
+	}
+	return result
+}
+
 //
 // Tests
 //
@@ -99,6 +109,14 @@ var helperTests = []Test{
 		map[string]interface{}{"echo": echoHelper},
 		nil,
 		`GnAK!GnAK!GnAK!`,
+	},
+	{
+		"helper with variadic parameters",
+		`{{variadic "GnAK!" 3 false}}`,
+		nil, nil,
+		map[string]interface{}{"variadic": variadicHelper},
+		nil,
+		`GnAK!3false`,
 	},
 	{
 		"#if helper with true literal",

--- a/internal/handlebarsjs/base_test.go
+++ b/internal/handlebarsjs/base_test.go
@@ -25,7 +25,7 @@ type Test struct {
 	output   interface{}
 }
 
-func launchTests(t *testing.T, tests []Test) {
+func launchTests(t *testing.T, tests ...Test) {
 	t.Parallel()
 
 	for _, test := range tests {

--- a/internal/handlebarsjs/basic_test.go
+++ b/internal/handlebarsjs/basic_test.go
@@ -614,7 +614,7 @@ var basicTests = []Test{
 }
 
 func TestBasic(t *testing.T) {
-	launchTests(t, basicTests)
+	launchTests(t, basicTests...)
 }
 
 func TestBasicErrors(t *testing.T) {

--- a/internal/handlebarsjs/blocks_test.go
+++ b/internal/handlebarsjs/blocks_test.go
@@ -2,10 +2,9 @@ package handlebarsjs
 
 import "testing"
 
-//
 // Those tests come from:
-//   https://github.com/wycats/handlebars.js/blob/master/spec/blocks.js
 //
+//	https://github.com/wycats/handlebars.js/blob/master/spec/blocks.js
 var blocksTests = []Test{
 	{
 		"array (1) - Arrays iterate over the contents when not empty",
@@ -204,5 +203,5 @@ var blocksTests = []Test{
 }
 
 func TestBlocks(t *testing.T) {
-	launchTests(t, blocksTests)
+	launchTests(t, blocksTests...)
 }

--- a/internal/handlebarsjs/builtins_test.go
+++ b/internal/handlebarsjs/builtins_test.go
@@ -2,10 +2,9 @@ package handlebarsjs
 
 import "testing"
 
-//
 // Those tests come from:
-//   https://github.com/wycats/handlebars.js/blob/master/spec/builtin.js
 //
+//	https://github.com/wycats/handlebars.js/blob/master/spec/builtin.js
 var builtinsTests = []Test{
 	{
 		"#if - if with boolean argument shows the contents when true",
@@ -337,5 +336,5 @@ var builtinsTests = []Test{
 }
 
 func TestBuiltins(t *testing.T) {
-	launchTests(t, builtinsTests)
+	launchTests(t, builtinsTests...)
 }

--- a/internal/handlebarsjs/data_test.go
+++ b/internal/handlebarsjs/data_test.go
@@ -295,5 +295,5 @@ var dataTests = []Test{
 }
 
 func TestData(t *testing.T) {
-	launchTests(t, dataTests)
+	launchTests(t, dataTests...)
 }

--- a/internal/handlebarsjs/helpers_test.go
+++ b/internal/handlebarsjs/helpers_test.go
@@ -662,5 +662,5 @@ var helpersTests = []Test{
 }
 
 func TestHelpers(t *testing.T) {
-	launchTests(t, helpersTests)
+	launchTests(t, helpersTests...)
 }

--- a/internal/handlebarsjs/partials_test.go
+++ b/internal/handlebarsjs/partials_test.go
@@ -2,10 +2,9 @@ package handlebarsjs
 
 import "testing"
 
-//
 // Those tests come from:
-//   https://github.com/wycats/handlebars.js/blob/master/spec/partials.js
 //
+//	https://github.com/wycats/handlebars.js/blob/master/spec/partials.js
 var partialsTests = []Test{
 	{
 		"basic partials",
@@ -178,5 +177,5 @@ var partialsTests = []Test{
 }
 
 func TestPartials(t *testing.T) {
-	launchTests(t, partialsTests)
+	launchTests(t, partialsTests...)
 }

--- a/internal/handlebarsjs/subexpressions_test.go
+++ b/internal/handlebarsjs/subexpressions_test.go
@@ -204,5 +204,5 @@ var subexpressionsTests = []Test{
 }
 
 func TestSubexpressions(t *testing.T) {
-	launchTests(t, subexpressionsTests)
+	launchTests(t, subexpressionsTests...)
 }

--- a/internal/handlebarsjs/whitespace_test.go
+++ b/internal/handlebarsjs/whitespace_test.go
@@ -2,10 +2,9 @@ package handlebarsjs
 
 import "testing"
 
-//
 // Those tests come from:
-//   https://github.com/wycats/handlebars.js/blob/master/spec/whitespace-control.js
 //
+//	https://github.com/wycats/handlebars.js/blob/master/spec/whitespace-control.js
 var whitespaceControlTests = []Test{
 	{
 		"should strip whitespace around mustache calls (1)",
@@ -255,5 +254,5 @@ var whitespaceControlTests = []Test{
 }
 
 func TestWhitespaceControl(t *testing.T) {
-	launchTests(t, whitespaceControlTests)
+	launchTests(t, whitespaceControlTests...)
 }


### PR DESCRIPTION
support for variadic helpers that can capture any number of arguments. It is supported by the AST, but the Golang implementation was limited in this manner. 

This is especially useful to implement helpers like: 

{#or something something_else yet_another_thing}body{/or}

```golang
// the method doesn't accept any params explicitly 
func variadicHelper(options *Options) string {
	params := options.Params()
	result := ""
	for i := 0; i < len(params); i++ {
		result += Str(params[i])
	}
	return result
}
```